### PR TITLE
fix : refresh token 등록시에 기존 refresh token을 삭제하지 않도록 변경

### DIFF
--- a/src/main/kotlin/taeyun/malanalter/alertitem/AlertService.kt
+++ b/src/main/kotlin/taeyun/malanalter/alertitem/AlertService.kt
@@ -1,6 +1,7 @@
 package taeyun.malanalter.alertitem
 
 import io.github.oshai.kotlinlogging.KotlinLogging
+import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.dao.with
 import org.jetbrains.exposed.v1.jdbc.SizedIterable
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
@@ -52,7 +53,7 @@ class AlertService(
             // fixme : exposed N+1 처리의 이상함?
             // with 절을 하면 bid는 in 절에 한번에 가져오는데 이 후에 왜 다시 하나씩 alert_item을 조회?
             // 없애면 item 개수만큼 bid에서 가져온다.
-            AlertItemEntity.find { AlertItemTable.userId eq principal.userId }
+            AlertItemEntity.find { AlertItemTable.userId eq principal.userId and (AlertItemTable.isAalarm eq true) }
                 .with(AlertItemEntity::bids)
                 .associate { it.id.value to take5BidDto(it.bids) }
         }

--- a/src/main/kotlin/taeyun/malanalter/auth/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/taeyun/malanalter/auth/JwtAuthenticationFilter.kt
@@ -50,7 +50,7 @@ class JwtAuthenticationFilter(
             }
             // 만료검사 : 만료시에 바로 Exception 이 발생
             if (jwtUtil.isExpiredToken(jwt)) {
-                throw AlerterJwtException(ErrorCode.EXPIRED_ACCESS_TOKEN, "만료된 액세스 토큰 요청")
+                throw AlerterJwtException(ErrorCode.EXPIRED_ACCESS_TOKEN, "$userId 만료된 액세스 토큰 요청")
             }
 
             // 없는 사용자라면 exception 배출

--- a/src/main/kotlin/taeyun/malanalter/auth/domain/RefreshToken.kt
+++ b/src/main/kotlin/taeyun/malanalter/auth/domain/RefreshToken.kt
@@ -1,10 +1,12 @@
 package taeyun.malanalter.auth.domain
 
 import kotlinx.datetime.toJavaLocalDateTime
+import org.jetbrains.exposed.v1.core.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.dao.id.EntityID
 import org.jetbrains.exposed.v1.dao.LongEntity
 import org.jetbrains.exposed.v1.dao.LongEntityClass
+import org.jetbrains.exposed.v1.jdbc.deleteWhere
 
 class RefreshToken(id: EntityID<Long>) : LongEntity(id) {
     companion object : LongEntityClass<RefreshToken>(RefreshTokens) {
@@ -13,7 +15,7 @@ class RefreshToken(id: EntityID<Long>) : LongEntity(id) {
         }
 
         fun deleteByUserId(id: Long){
-            RefreshToken.find { RefreshTokens.userId eq id }.firstOrNull()?.delete()
+            RefreshTokens.deleteWhere { userId eq id}
         }
     }
 


### PR DESCRIPTION
- 유저가 여러 단말로 로그인할경우 한 단말은 리프레시가 되지 않음.
- 리프레시에서도 기존 리프레시를 지우지 않고 액세스 토큰생성
- 로그아웃 시에만 전체를 삭제