### PR TITLE
fix: update alertItemId handling to use reference type and improve performance

### DIFF
--- a/src/main/kotlin/taeyun/malanalter/ItemCheckerV2.kt
+++ b/src/main/kotlin/taeyun/malanalter/ItemCheckerV2.kt
@@ -53,7 +53,7 @@ class ItemCheckerV2(
             val allUserEntityMap: Map<Long, UserEntity> = userService.getAllUserEntityMap()
             val itemsByUser = alertRepository.getRegisteredItem().groupBy { it.userId }
             val savedBidsByItemId: Map<Int, List<ItemBidEntity>> =
-                alertRepository.getAllItemComments().groupBy { it.alertItemId }
+                alertRepository.getAllItemComments().groupBy { it.alertItemId.value }
 
             itemsByUser.forEach { (userId, registeredItems) ->
                 launch {

--- a/src/main/kotlin/taeyun/malanalter/alertitem/AlertService.kt
+++ b/src/main/kotlin/taeyun/malanalter/alertitem/AlertService.kt
@@ -49,21 +49,15 @@ class AlertService(
     fun getAllBidOfUser(): Map<Int, List<ItemBidDto>> {
         val principal = SecurityContextHolder.getContext().authentication.principal as AlerterUserPrincipal
         return transaction {
-//            addLogger(StdOutSqlLogger)
-            // fixme : exposed N+1 처리의 이상함?
-            // with 절을 하면 bid는 in 절에 한번에 가져오는데 이 후에 왜 다시 하나씩 alert_item을 조회?
-            // 없애면 item 개수만큼 bid에서 가져온다.
             AlertItemEntity.find { AlertItemTable.userId eq principal.userId and (AlertItemTable.isAalarm eq true) }
                 .with(AlertItemEntity::bids)
-                .associate { it.id.value to take5BidDto(it.bids) }
+                .associate { it.id.value to take5BidDto(it.bids, it.tradeType) }
         }
     }
 
-    private fun take5BidDto(bids: SizedIterable<ItemBidEntity>): List<ItemBidDto> {
+    private fun take5BidDto(bids: SizedIterable<ItemBidEntity>, tradeType: TradeType): List<ItemBidDto> {
         val filteredBids = bids.filter { it.isAlarm }
         if (filteredBids.isEmpty()) return emptyList()
-        
-        val tradeType = filteredBids.first().alertItem.tradeType
         return filteredBids
             .sortedWith(
                 if (tradeType == TradeType.BUY) {

--- a/src/main/kotlin/taeyun/malanalter/alertitem/domain/ItemBidTable.kt
+++ b/src/main/kotlin/taeyun/malanalter/alertitem/domain/ItemBidTable.kt
@@ -4,7 +4,7 @@ import org.jetbrains.exposed.v1.core.ReferenceOption
 import org.jetbrains.exposed.v1.core.dao.id.LongIdTable
 
 object ItemBidTable: LongIdTable("item_bid") {
-    val alertItemId = integer("alert_item_id").references(AlertItemTable.id, onDelete = ReferenceOption.CASCADE)
+    val alertItemId = reference("alert_item_id", AlertItemTable.id, onDelete = ReferenceOption.CASCADE)
     val url = varchar("bid_url", 255).index(isUnique = false)
     val price = long("price")
     val comment = varchar("comment", 255).nullable()

--- a/src/test/kotlin/taeyun/malanalter/alertitem/repository/AlertItemRepositoryTest.kt
+++ b/src/test/kotlin/taeyun/malanalter/alertitem/repository/AlertItemRepositoryTest.kt
@@ -64,7 +64,7 @@ class AlertItemRepositoryTest(
             val savedBids = ItemBidEntity.all().toList()
             savedBids.size shouldBe 2
             savedBids.map { it.url }.toSet() shouldBe setOf("testUrl1", "testUrl2")
-            savedBids.all { it.alertItemId == alertId } shouldBe true
+            savedBids.all { it.alertItemId.value == alertId } shouldBe true
         }
 
 


### PR DESCRIPTION
**Description**

해당 이슈는 https://github.com/JetBrains/Exposed/pull/2614 Exposed의 방지되지 않은 references 함수의 동작으로 유저가 Table 관계를 `reference()` 아닌 `references()`로 만들게 될 시 `with()` 사용시 캐시된 Entity가 사용되지 않는 이슈가 있었음. 

우선 해결책으로 reference 로 변경 후 쿼리 확인 결과 정상 동작을 확인.